### PR TITLE
Use new Laravel 5.4's Session contract

### DIFF
--- a/src/Drivers/SessionDriver.php
+++ b/src/Drivers/SessionDriver.php
@@ -2,13 +2,13 @@
 
 namespace Lykegenes\LocaleSwitcher\Drivers;
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Illuminate\Contracts\Session\Session;
 
 class SessionDriver extends BaseDriver
 {
     protected $session;
 
-    public function __construct(SessionInterface $session)
+    public function __construct(Session $session)
     {
         $this->session = $session;
     }


### PR DESCRIPTION
From upgrade doc : Laravel's session handlers no longer implements
Symfony's SessionInterface. Implementing this interface required us to
implement extraneous features that were not needed by the framework.
Instead, a new Illuminate\Contracts\Session\Session interface has been
defined and may be used instead.